### PR TITLE
perf(queries): N+1s, índices faltantes y writes-on-read

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -3,7 +3,7 @@ class EmployeesController < ApplicationController
 
   def index
     @q = Employee.ransack(params[:q])
-    @employees = @q.result.paginate(page: params[:page], per_page: 10)
+    @employees = @q.result.includes(:group).paginate(page: params[:page], per_page: 10)
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@ class EventsController < ApplicationController
   # GET /events
   def index
     @q = Event.ransack(params[:q])
-    @events = @q.result.paginate(page: params[:page])
+    @events = @q.result.includes(:employee).paginate(page: params[:page])
   end
 
   # GET /events/1

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,7 +13,9 @@ class HomeController < ApplicationController
     end
 
     # Query attendance records directly with date range
-    @attendance_records = AttendanceRecord.where(entry_time: @date_range).order(entry_time: :desc).limit(10)
+    @attendance_records = AttendanceRecord.where(entry_time: @date_range)
+                                          .includes(employee: :group)
+                                          .order(entry_time: :desc).limit(10)
     @attendance_records_count = AttendanceRecord.where(entry_time: @date_range).count
     @employees = Employee.count
     @incidents_count = Incident.where(created_at: @date_range).count

--- a/app/controllers/payrolls_controller.rb
+++ b/app/controllers/payrolls_controller.rb
@@ -3,10 +3,12 @@ class PayrollsController < ApplicationController
 
   def index
     @q = Payroll.ransack(params[:q])
-    @payrolls = @q.result.includes(:employee).paginate(page: params[:page])
+    @payrolls = @q.result.includes(:employee, :incidents).paginate(page: params[:page])
   end
 
   def show
+    @attendance_records = @payroll.attendance_records.includes(:schedule)
+
     @not_worked_days = @payroll.incidents
                          .where("issue LIKE ?", "%No se presentó%")
                          .count

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,18 @@
 class ReportsController < ApplicationController
+  # Feed de actividad combinado. Antes cargaba las 4 tablas COMPLETAS en memoria
+  # (AttendanceRecord.all + ...), lo que crece sin cota. Ahora tomamos solo las
+  # más recientes de cada tipo y las mezclamos ordenadas por fecha.
+  RECENT_ACTIVITY_LIMIT = 200
+
   def index
-    @reports = AttendanceRecord.all + OvertimeRecord.all + Incident.all + Absence.all
+    recent = [
+      AttendanceRecord.reorder(created_at: :desc).limit(RECENT_ACTIVITY_LIMIT),
+      OvertimeRecord.reorder(created_at: :desc).limit(RECENT_ACTIVITY_LIMIT),
+      Incident.reorder(created_at: :desc).limit(RECENT_ACTIVITY_LIMIT),
+      Absence.reorder(created_at: :desc).limit(RECENT_ACTIVITY_LIMIT)
+    ].flat_map(&:to_a)
+
+    @reports = recent.sort_by(&:created_at).reverse.first(RECENT_ACTIVITY_LIMIT)
   end
 
   def show

--- a/app/models/attendance_record.rb
+++ b/app/models/attendance_record.rb
@@ -58,11 +58,12 @@ class AttendanceRecord < ApplicationRecord
     )
   end
 
+  # Asigna el horario en memoria si falta, pero NO persiste durante la lectura.
+  # Escribir dentro de after_find provoca UPDATEs en cada carga de registro
+  # (writes-on-read + N+1). El horario ya se asigna al crear vía before_validation;
+  # el backfill de registros antiguos debe hacerse con una tarea explícita.
   def check_and_assign_schedule
-    if schedule.nil?
-      assign_schedule
-      save if schedule.present?
-    end
+    assign_schedule if schedule.nil?
   end
 
   def set_defaults

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -53,8 +53,17 @@ class Employee < ApplicationRecord
 
   # Obtener registros de asistencia no procesados en un rango de fechas
   def unprocessed_attendance_records(start_date, end_date)
-    attendance_records.where(processed: false, entry_time: start_date.beginning_of_day..end_date.end_of_day)
-                      .reject { |record| on_leave?(record.entry_time.to_date) }
+    records = attendance_records.where(processed: false, entry_time: start_date.beginning_of_day..end_date.end_of_day)
+
+    # Cargamos las ausencias que solapan el rango una sola vez (antes se hacía un
+    # `absences.exists?` por cada registro). El WHERE descarta filas con fechas nulas,
+    # así que la comparación en memoria es segura.
+    leave_ranges = absences.where("start_date <= ? AND end_date >= ?", end_date, start_date).to_a
+
+    records.reject do |record|
+      date = record.entry_time.to_date
+      leave_ranges.any? { |absence| absence.start_date <= date && absence.end_date >= date }
+    end
   end
 
   # Calcular las horas trabajadas excluyendo almuerzo

--- a/app/models/payroll.rb
+++ b/app/models/payroll.rb
@@ -38,12 +38,16 @@ class Payroll < ApplicationRecord
 
   # Método principal para calcular los totales
   def calculate_totals(include_lunch)
+    # Leemos el ajuste una sola vez; AppSetting.lunch_hours hace un SELECT por llamada
+    # y antes se ejecutaba una vez por cada registro dentro del bloque sum.
+    lunch_hours = AppSetting.lunch_hours
+
     # Calcular totales en base al rango de fechas
     self.total_hours_worked = attendance_records.where(entry_time: start_date.beginning_of_day..end_date.end_of_day).sum do |record|
       if record.exit_time
         hours = (record.exit_time - record.entry_time) / 3600.0
         # Subtract lunch hour if worked more than 4 hours and include_lunch is true
-        include_lunch && hours > 4 ? hours - AppSetting&.lunch_hours : hours
+        include_lunch && hours > 4 ? hours - lunch_hours : hours
       else
         0
       end

--- a/app/services/attendance_processor_service.rb
+++ b/app/services/attendance_processor_service.rb
@@ -1,6 +1,7 @@
 class AttendanceProcessorService
   def initialize
     @processed_count = 0
+    @first_device_id = Device.first&.id
   end
 
   def call
@@ -133,12 +134,13 @@ class AttendanceProcessorService
     DateTime.parse("#{event.date} #{event.time}")
   end
 
-  def first_device_id
-    Device.first&.id
-  end
+  attr_reader :first_device_id
 
   def mark_events_as_processed(events)
-    events.each { |e| e.update(processed: true) }
+    ids = events.map(&:id)
+    return if ids.empty?
+
+    Event.where(id: ids).update_all(processed: true, updated_at: Time.current)
   end
 
   def log_success(employee_id, entry_time, exit_time)

--- a/app/services/work_hours_service.rb
+++ b/app/services/work_hours_service.rb
@@ -31,20 +31,24 @@ class WorkHoursService
   def verify_missing_attendance
     # Obtiene todos los schedules para el grupo del empleado en el rango de fechas
     schedules = Schedule.where(group_id: @employee.group_id, date: @start_date..@end_date)
+    return if schedules.empty?
+
+    # Cargamos las fechas con asistencia del rango en una sola consulta, en lugar
+    # de ejecutar un `exists?` por cada schedule.
+    attended_dates = @employee.attendance_records
+                              .where(entry_time: @start_date.beginning_of_day..@end_date.end_of_day)
+                              .pluck(:entry_time)
+                              .map(&:to_date)
+                              .to_set
 
     schedules.each do |schedule|
-      # Revisa si hay algún registro de asistencia para ese día
-      attendance_exists = @employee.attendance_records.where(
-        entry_time: schedule.date.beginning_of_day..schedule.date.end_of_day
-      ).exists?
+      next if attended_dates.include?(schedule.date)
 
-      unless attendance_exists
-        # Si no se encontró ningún registro, se crea el incidente correspondiente.
-        IncidentManager.new(@employee).create_incident(
-          schedule,
-          "No se presentó para el horario del #{schedule.date} a las #{schedule.expected_entry_time.strftime('%H:%M')}"
-        )
-      end
+      # Si no se encontró ningún registro, se crea el incidente correspondiente.
+      IncidentManager.new(@employee).create_incident(
+        schedule,
+        "No se presentó para el horario del #{schedule.date} a las #{schedule.expected_entry_time.strftime('%H:%M')}"
+      )
     end
   end
 end

--- a/app/views/payrolls/index.html.erb
+++ b/app/views/payrolls/index.html.erb
@@ -76,7 +76,7 @@
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= payroll.end_date.strftime("%d/%m/%Y") %></td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= payroll.total_hours_worked %></td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= payroll.total_overtime_hours %></td>
-                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= payroll&.incidents&.count %></td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= payroll&.incidents&.size %></td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= number_to_currency(payroll.total_payment) %></td>
                   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                     <%= link_to "Ver", payroll_path(payroll), class: "text-indigo-600 hover:text-indigo-900" %>

--- a/app/views/payrolls/show.html.erb
+++ b/app/views/payrolls/show.html.erb
@@ -180,7 +180,7 @@
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200">
-            <% @payroll.attendance_records.each do |record| %>
+            <% @attendance_records.each do |record| %>
               <tr>
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900">
                   <%= record.entry_time.strftime("%d/%m/%Y") %>

--- a/db/migrate/20260715120000_add_performance_indexes.rb
+++ b/db/migrate/20260715120000_add_performance_indexes.rb
@@ -1,0 +1,21 @@
+class AddPerformanceIndexes < ActiveRecord::Migration[8.0]
+  def change
+    # Núcleo de asistencia: se consulta por empleado + rango de entry_time y por estado de procesamiento.
+    add_index :attendance_records, [ :employee_id, :entry_time ], if_not_exists: true
+    add_index :attendance_records, :device_id, if_not_exists: true
+    add_index :attendance_records, :processed, if_not_exists: true
+
+    # Cálculo de nómina/overtime e incidencias por empleado y fecha.
+    add_index :overtime_records, [ :employee_id, :date ], if_not_exists: true
+    add_index :incidents, [ :employee_id, :date ], if_not_exists: true
+
+    # Listado/join de empleados por grupo.
+    add_index :employees, :group_id, if_not_exists: true
+
+    # Orden por defecto de eventos (date/time desc) y procesamiento por fecha.
+    add_index :events, [ :date, :time ], if_not_exists: true
+
+    # Consulta de ausencias por empleado y rango (on_leave? / unprocessed_attendance_records).
+    add_index :absences, [ :employee_id, :start_date, :end_date ], if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_08_121214) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_15_120000) do
   create_table "absences", force: :cascade do |t|
     t.bigint "employee_id", null: false
     t.date "start_date"
@@ -19,6 +19,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_121214) do
     t.string "reason"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["employee_id", "start_date", "end_date"], name: "index_absences_on_employee_id_and_start_date_and_end_date"
     t.index ["employee_id"], name: "index_absences_on_employee_id"
   end
 
@@ -38,6 +39,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_121214) do
     t.datetime "updated_at", null: false
     t.boolean "processed"
     t.bigint "schedule_id"
+    t.index ["device_id"], name: "index_attendance_records_on_device_id"
+    t.index ["employee_id", "entry_time"], name: "index_attendance_records_on_employee_id_and_entry_time"
+    t.index ["processed"], name: "index_attendance_records_on_processed"
     t.index ["schedule_id"], name: "index_attendance_records_on_schedule_id"
   end
 
@@ -62,6 +66,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_121214) do
     t.string "document_number"
     t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_employees_on_deleted_at"
+    t.index ["group_id"], name: "index_employees_on_group_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -82,6 +87,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_121214) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "processed", default: false
+    t.index ["date", "time"], name: "index_events_on_date_and_time"
     t.index ["device_id"], name: "index_events_on_device_id"
     t.index ["employee_id"], name: "index_events_on_employee_id"
   end
@@ -99,6 +105,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_121214) do
     t.boolean "resolved"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["employee_id", "date"], name: "index_incidents_on_employee_id_and_date"
   end
 
   create_table "overtime_records", force: :cascade do |t|
@@ -108,6 +115,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_08_121214) do
     t.decimal "compensation"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["employee_id", "date"], name: "index_overtime_records_on_employee_id_and_date"
   end
 
   create_table "payroll_entries", force: :cascade do |t|


### PR DESCRIPTION
## Resumen

Optimizaciones de **rendimiento** derivadas del análisis de la aplicación. Ataca las rutas de mayor costo (N+1, tablas sin índices, escrituras durante lecturas) **preservando la lógica de negocio**. El único cambio de comportamiento intencional es el acotado de `reports#index` (ver más abajo).

## Cambios

### 🗃️ Índices (migración `AddPerformanceIndexes`)
Tabla núcleo `attendance_records` sin ningún índice de negocio; se agregan:
- `attendance_records` → `[employee_id, entry_time]`, `device_id`, `processed`
- `overtime_records` / `incidents` → `[employee_id, date]`
- `employees` → `group_id`
- `events` → `[date, time]` (respalda el `default_scope` de orden y el procesamiento)
- `absences` → `[employee_id, start_date, end_date]`

Idempotente (`if_not_exists: true`).

### ✍️ Fin de las escrituras-en-lectura
`AttendanceRecord#after_find` ejecutaba `save` en **cada carga** de registro (UPDATE + N+1 por lectura). Ahora solo asigna el horario **en memoria**; la asignación al crear (`before_validation`) no cambia.
> El backfill de registros históricos con `schedule_id` nulo debería hacerse con una tarea explícita (follow-up).

### 🔗 N+1 resueltos con `includes`
- `home#index` → `includes(employee: :group)`
- `employees#index` → `includes(:group)`
- `events#index` → `includes(:employee)`
- `payrolls#index` → `includes(:incidents)` + `.count`→`.size` en la vista
- `payrolls#show` → `attendance_records.includes(:schedule)`

### 📉 `reports#index` acotado
Antes: `AttendanceRecord.all + OvertimeRecord.all + Incident.all + Absence.all` → cargaba **4 tablas completas** en memoria (crece sin cota). Ahora toma las **200 más recientes** de cada tipo y las mezcla por fecha.
> ⚠️ **Cambio de comportamiento**: la vista pasa de "todo el historial" a "actividad reciente" (200/tipo). El feed no tenía paginación; la vista muestra un placeholder en la columna de detalle.

### ⚙️ Servicios/modelos
- `Payroll#calculate_totals` lee `AppSetting.lunch_hours` una vez (era **un SELECT por registro** dentro del `sum`).
- `AttendanceProcessorService`: memoiza `Device.first` y marca eventos con un `update_all` por lote (antes: un `update` por evento).
- `WorkHoursService#verify_missing_attendance` y `Employee#unprocessed_attendance_records`: cargan asistencia/ausencias del rango **una sola vez** en vez de un `exists?`/consulta por iteración.

## Verificación
- ✅ Migración aplica y regenera `db/schema.rb` (los 8 índices presentes).
- ✅ `rubocop` (omakase) sin ofensas en los 11 archivos.
- ✅ Suite de tests verde.
- ✅ Checks directos vía `bin/rails runner` (datos temporales en transacción):
  - `after_find` ya **no** persiste en lectura (`updated_at` intacto).
  - `unprocessed_attendance_records` sigue excluyendo días con ausencia.
  - `verify_missing_attendance` sigue creando incidencias para días sin asistencia.
  - `includes(:incidents)` polimórfico y `attendance_records.includes(:schedule)` ejecutan sin error.

> Nota: la mayoría de los tests existentes son placeholders vacíos (solo 1 test real corre), por eso la verificación se hizo también de forma directa. Cubrir la capa de servicios con tests es un follow-up recomendado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)