### PR TITLE
Fix: asistencia del sereno, importaciones estables y login

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -34,8 +34,14 @@ class EventsController < ApplicationController
   # POST /events/import
   def import
     if params[:file].present?
-      EventImportService.new(params[:file].path).call
-      redirect_to events_path, notice: "Eventos importados exitosamente."
+      result = EventImportService.new(params[:file].path).call
+      message = "Importación: #{result[:total_imported]} eventos nuevos, #{result[:skipped_duplicates]} duplicados omitidos."
+
+      if result[:errors].any?
+        redirect_to events_path, alert: "#{message} Errores (#{result[:errors].size}): #{result[:errors].first(3).join(' — ')}"
+      else
+        redirect_to events_path, notice: message
+      end
     else
       redirect_to events_path, alert: "Por favor seleccione un archivo para importar."
     end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -52,9 +52,10 @@ class Employee < ApplicationRecord
   end
 
   # El sereno (vigilante nocturno) tiene turnos que cruzan la medianoche y se
-  # procesa con una lógica de asistencia propia.
+  # procesa con una lógica de asistencia propia. Se detecta por inclusión porque
+  # en producción el grupo se llama "Sereno - Diosnel", no "Sereno" a secas.
   def sereno?
-    group&.name&.downcase == "sereno"
+    group&.name&.downcase&.include?("sereno") || false
   end
 
   # Obtener registros de asistencia no procesados en un rango de fechas

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -51,6 +51,12 @@ class Employee < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  # El sereno (vigilante nocturno) tiene turnos que cruzan la medianoche y se
+  # procesa con una lógica de asistencia propia.
+  def sereno?
+    group&.name&.downcase == "sereno"
+  end
+
   # Obtener registros de asistencia no procesados en un rango de fechas
   def unprocessed_attendance_records(start_date, end_date)
     records = attendance_records.where(processed: false, entry_time: start_date.beginning_of_day..end_date.end_of_day)

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -36,9 +36,21 @@ class Schedule < ApplicationRecord
 
   # Métodos de instancia
   def formatted_duration
-    total_seconds = expected_exit_time - expected_entry_time
+    total_seconds = effective_expected_exit_time - expected_entry_time
     total_seconds -= 1.hour if include_lunch? && total_seconds > 4.hours
     Time.at(total_seconds).utc.strftime("%H:%M horas")
+  end
+
+  # Determina si el horario cruza la medianoche (turno nocturno: entrada 20:00, salida 04:00).
+  # Ambos datetimes se guardan sobre la fecha de entrada, por eso entrada > salida.
+  def crosses_midnight?
+    expected_entry_time > expected_exit_time
+  end
+
+  # La salida esperada real: si el turno cruza la medianoche, cae al día siguiente.
+  # Usar siempre esta versión para comparar contra horas de salida reales.
+  def effective_expected_exit_time
+    crosses_midnight? ? expected_exit_time + 1.day : expected_exit_time
   end
 
   def day_of_week
@@ -62,11 +74,6 @@ class Schedule < ApplicationRecord
     if expected_entry_time >= expected_exit_time && !crosses_midnight?
       errors.add(:expected_exit_time, "debe ser posterior a la hora de entrada")
     end
-  end
-
-  # Determina si el horario cruza la medianoche
-  def crosses_midnight?
-    expected_entry_time > expected_exit_time
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/services/attendance_processor_service.rb
+++ b/app/services/attendance_processor_service.rb
@@ -90,27 +90,20 @@ class AttendanceProcessorService
   def handle_standard_attendance(employee, events)
     return if events.empty?
 
-    events_by_date = events.group_by(&:date).sort.to_h
-    used_event_ids = []
+    events.group_by(&:date).sort.each do |_date, day_events|
+      sorted_day_events = day_events.sort_by(&:time)
 
-    events_by_date.each do |_date, day_events|
-      sorted_day_events = day_events.reject { |e| used_event_ids.include?(e.id) }.sort_by(&:time)
-      next if sorted_day_events.empty?
-
-      entry_event = sorted_day_events.first
-      exit_event  = sorted_day_events.last
-
-      entry_time = build_datetime(entry_event)
-      exit_time  = build_datetime(exit_event)
+      entry_time = build_datetime(sorted_day_events.first)
+      exit_time  = build_datetime(sorted_day_events.last)
 
       # Verificamos si la diferencia es al menos 5 horas
       hours_diff = ((exit_time - entry_time) * 24).to_f
       exit_time = nil if hours_diff < 5
 
-      create_attendance_record(employee.id, entry_time, exit_time, [ entry_event, exit_event ].uniq)
-
-      used_event_ids << entry_event.id
-      used_event_ids << exit_event.id if exit_time
+      # El registro consume TODOS los golpes del día: los intermedios son
+      # re-marcaciones de la misma jornada y, si quedaran pendientes, la próxima
+      # corrida los convertiría en registros basura "sin salida".
+      create_attendance_record(employee.id, entry_time, exit_time, sorted_day_events)
     end
   end
 

--- a/app/services/attendance_processor_service.rb
+++ b/app/services/attendance_processor_service.rb
@@ -1,4 +1,9 @@
 class AttendanceProcessorService
+  # Un turno real dura ~8h (19:50 → 04:00); pasada esta ventana la salida se da por perdida.
+  SERENO_MAX_SHIFT_HOURS = 14
+  # Golpes más cercanos que esto son re-marcaciones del mismo ingreso, no un turno.
+  SERENO_MIN_SHIFT_HOURS = 4
+
   def initialize
     @processed_count = 0
     @first_device_id = Device.first&.id
@@ -16,7 +21,7 @@ class AttendanceProcessorService
     grouped_events = Event
                       .where(processed: false)
                       .where.not(employee_id: nil)
-                      .order(:employee_id, :date, :time)
+                      .reorder(:employee_id, :date, :time)
                       .group_by(&:employee_id)
 
     grouped_events.each do |employee_id, events|
@@ -35,49 +40,51 @@ class AttendanceProcessorService
 
     sorted_events = valid_events(events).sort_by { |e| [ e.date, e.time ] }
 
-    if sereno?(employee)
+    if employee.sereno?
       process_sereno_events(employee, sorted_events)
     else
       handle_standard_attendance(employee, sorted_events)
     end
   end
 
-  def sereno?(employee)
-    employee.group&.name&.downcase == "sereno"
-  end
-
+  # El sereno marca al entrar (~20:00) y al salir (~04:00 del día siguiente), a veces
+  # con re-marcaciones. Recorremos sus eventos como un stream cronológico: el primer
+  # evento no consumido abre un turno y el último golpe dentro de la ventana de
+  # SERENO_MAX_SHIFT_HOURS lo cierra; los golpes intermedios son re-marcaciones.
+  # Así una salida matinal nunca puede volver a usarse como entrada del día siguiente.
   def process_sereno_events(employee, events)
-    used_entry_ids = []
-    used_exit_ids = []
-    events_by_date = events.group_by(&:date).sort.to_h
+    index = 0
 
-    events_by_date.each_with_index do |(date, day_events), idx|
-      entry_event = day_events.reject { |e| used_entry_ids.include?(e.id) }.last
-      next unless entry_event
-
-      next_date = events_by_date.keys[idx + 1]
-      next_events = events_by_date[next_date]
-      next unless next_events&.any?
-
-      exit_event = next_events.reject { |e| used_exit_ids.include?(e.id) }.first
-      next unless exit_event
-
+    while index < events.length
+      entry_event = events[index]
       entry_time = build_datetime(entry_event)
-      exit_time = build_datetime(exit_event)
 
-      hours_diff = ((exit_time - entry_time) * 24).to_f
+      window = shift_window(events, index, entry_time)
+      exit_event = window.last
 
-      if hours_diff > 14
-        # si se pasa de las 14 horas, lo marcamos como sin salida, pero NO usamos el exit_event
-        create_attendance_record(employee.id, entry_time, nil, [ entry_event ])
-        used_entry_ids << entry_event.id
-        next
+      if exit_event && hours_between(entry_time, build_datetime(exit_event)) >= SERENO_MIN_SHIFT_HOURS
+        create_attendance_record(employee.id, entry_time, build_datetime(exit_event), [ entry_event, *window ])
+      elsif index + window.length + 1 >= events.length
+        # La entrada (y sus re-marcaciones) son la cola del stream: la salida puede
+        # llegar en la próxima importación, así que quedan pendientes (processed: false).
+        break
+      else
+        # El siguiente golpe está a más de SERENO_MAX_SHIFT_HOURS: salida perdida.
+        create_attendance_record(employee.id, entry_time, nil, [ entry_event, *window ])
       end
 
-      create_attendance_record(employee.id, entry_time, exit_time, [ entry_event, exit_event ])
-      used_entry_ids << entry_event.id
-      used_exit_ids << exit_event.id
+      index += 1 + window.length
     end
+  end
+
+  def shift_window(events, index, entry_time)
+    events[(index + 1)..].take_while do |event|
+      hours_between(entry_time, build_datetime(event)) <= SERENO_MAX_SHIFT_HOURS
+    end
+  end
+
+  def hours_between(from, to)
+    ((to - from) * 24).to_f
   end
 
   def handle_standard_attendance(employee, events)
@@ -117,6 +124,13 @@ class AttendanceProcessorService
       employee_id: employee_id,
       entry_time: entry_time
     )
+
+    # Nunca degradar un registro que ya tiene salida: un reproceso sin la salida
+    # a la vista (p. ej. una re-importación parcial) no debe borrar datos buenos.
+    if attendance.persisted? && attendance.exit_time.present? && exit_time.nil?
+      mark_events_as_processed(events)
+      return
+    end
 
     attendance.exit_time = exit_time
     attendance.device_id = first_device_id

--- a/app/services/event_import_service.rb
+++ b/app/services/event_import_service.rb
@@ -53,9 +53,11 @@ class EventImportService
   end
 
   def find_or_create_employee(document_number)
-    return nil unless document_number.present?
+    # Las lecturas fallidas del dispositivo vienen con sJobNo = "'" (solo el prefijo
+    # de Excel): sin documento real no hay empleado que crear ni asistencia que generar.
+    cleaned_document = document_number.to_s.delete_prefix("'")
+    return nil if cleaned_document.blank?
 
-    cleaned_document = document_number.delete_prefix("'")
     Employee.find_or_create_by!(document_number: cleaned_document)
   rescue ActiveRecord::RecordInvalid => e
     @errors << "⚠️ Error al crear empleado con documento #{document_number}: #{e.message}"

--- a/app/services/event_import_service.rb
+++ b/app/services/event_import_service.rb
@@ -4,6 +4,7 @@ class EventImportService
   def initialize(file_path)
     @file_path = file_path
     @imported_count = 0
+    @skipped_duplicates = 0
     @errors = []
   end
 
@@ -47,6 +48,8 @@ class EventImportService
     else
       @errors << "⚠️ Error en fila #{row['sJobNo']}: #{event.errors.full_messages.join(', ')}"
     end
+  rescue ActiveRecord::RecordNotUnique
+    @skipped_duplicates += 1
   end
 
   def find_or_create_employee(document_number)
@@ -67,6 +70,7 @@ class EventImportService
   def summary
     {
       total_imported: @imported_count,
+      skipped_duplicates: @skipped_duplicates,
       errors: @errors
     }
   end

--- a/app/services/overtime_calculator.rb
+++ b/app/services/overtime_calculator.rb
@@ -16,11 +16,14 @@ class OvertimeCalculator
     # Si la llegada tardía está dentro del tiempo de tolerancia, se ignora
     late_minutes = 0 if late_minutes <= (tolerance / 60.0)
 
-    # Verificar si hay horas extra (salida después de la hora esperada)
-    return 0 unless @record.exit_time > @schedule.expected_exit_time
+    # Verificar si hay horas extra (salida después de la hora esperada).
+    # effective_expected_exit_time corre la salida al día siguiente cuando el
+    # horario cruza la medianoche; comparar contra expected_exit_time directo
+    # inflaba ~24h de extras por noche para el sereno.
+    return 0 unless @record.exit_time > @schedule.effective_expected_exit_time
 
     # Calcular horas trabajadas después de la salida esperada
-    extra_hours = (@record.exit_time - @schedule.expected_exit_time) / 3600.0
+    extra_hours = (@record.exit_time - @schedule.effective_expected_exit_time) / 3600.0
 
     # Restar el tiempo de llegada tardía (convertido a horas)
     overtime_hours = extra_hours - (late_minutes / 60.0)

--- a/app/services/work_hours_service.rb
+++ b/app/services/work_hours_service.rb
@@ -35,11 +35,18 @@ class WorkHoursService
 
     # Cargamos las fechas con asistencia del rango en una sola consulta, en lugar
     # de ejecutar un `exists?` por cada schedule.
-    attended_dates = @employee.attendance_records
-                              .where(entry_time: @start_date.beginning_of_day..@end_date.end_of_day)
-                              .pluck(:entry_time)
-                              .map(&:to_date)
-                              .to_set
+    punches = @employee.attendance_records
+                       .where(entry_time: @start_date.beginning_of_day..@end_date.end_of_day)
+                       .pluck(:entry_time, :exit_time)
+
+    attended_dates = punches.map { |entry_time, _| entry_time.to_date }.to_set
+
+    # El turno del sereno cruza la medianoche: la mañana en que sale también cuenta
+    # como fecha asistida, para no marcar "No se presentó" el día posterior a su
+    # última noche trabajada cuando hay horarios cargados en bloque.
+    if @employee.sereno?
+      attended_dates.merge(punches.filter_map { |_, exit_time| exit_time&.to_date })
+    end
 
     schedules.each do |schedule|
       next if attended_dates.include?(schedule.date)

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="h-full">
+<html class="h-full bg-gray-50">
   <head>
     <title><%= content_for(:title) || "Multicarnes" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -23,12 +23,10 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-gray-200">
-    <main class="mt-28">
+  <body class="h-full">
+    <main class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
       <%= render "layouts/shared/notice" %>
-      <div class="shadow rounded-[4vw] bg-white mx-48 pb-4">
-        <%= yield %>
-      </div>
+      <%= yield %>
     </main>
   </body>
 </html>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
 
 <div class="sm:mx-auto sm:w-full sm:max-w-md">
   <div class="mx-auto flex size-12 items-center justify-center rounded-xl bg-indigo-600 shadow-sm">

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,25 +1,41 @@
-<h2>Change your password</h2>
+<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+<div class="sm:mx-auto sm:w-full sm:max-w-md">
+  <div class="mx-auto flex size-12 items-center justify-center rounded-xl bg-indigo-600 shadow-sm">
+    <svg class="size-7 text-white" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z" />
+    </svg>
+  </div>
+  <h1 class="mt-5 text-center text-2xl font-bold tracking-tight text-gray-900">Nueva contraseña</h1>
+  <p class="mt-1 text-center text-sm leading-6 text-gray-500">Elegí tu nueva contraseña para ingresar</p>
+</div>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+<div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+  <div class="bg-white px-6 py-10 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl sm:px-10">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-6" }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
+
+      <div>
+        <%= f.label :password, "Nueva contraseña", class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= f.password_field :password, autofocus: true, autocomplete: "new-password", required: true, class: input_classes %>
+        </div>
+        <% if @minimum_password_length %>
+          <p class="mt-2 text-xs leading-5 text-gray-500">Mínimo <%= @minimum_password_length %> caracteres</p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation, "Confirmar contraseña", class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: input_classes %>
+        </div>
+      </div>
+
+      <%= f.submit "Cambiar mi contraseña", class: "block w-full cursor-pointer rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+  <%= render "users/shared/links" %>
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
 
 <div class="sm:mx-auto sm:w-full sm:max-w-md">
   <div class="mx-auto flex size-12 items-center justify-center rounded-xl bg-indigo-600 shadow-sm">

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,16 +1,30 @@
-<h2>Forgot your password?</h2>
+<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+<div class="sm:mx-auto sm:w-full sm:max-w-md">
+  <div class="mx-auto flex size-12 items-center justify-center rounded-xl bg-indigo-600 shadow-sm">
+    <svg class="size-7 text-white" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z" />
+    </svg>
+  </div>
+  <h1 class="mt-5 text-center text-2xl font-bold tracking-tight text-gray-900">Recuperar contraseña</h1>
+  <p class="mt-1 text-center text-sm leading-6 text-gray-500">Te enviaremos instrucciones a tu correo</p>
+</div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+  <div class="bg-white px-6 py-10 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl sm:px-10">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-6" }) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
+
+      <div>
+        <%= f.label :email, "Correo electrónico", class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", required: true, class: input_classes %>
+        </div>
+      </div>
+
+      <%= f.submit "Enviar instrucciones", class: "block w-full cursor-pointer rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+    <% end %>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+  <%= render "users/shared/links" %>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
 
 <div class="sm:mx-auto sm:w-full sm:max-w-md">
   <div class="mx-auto flex size-12 items-center justify-center rounded-xl bg-indigo-600 shadow-sm">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,57 +1,66 @@
-<div class="flex justify-center min-h-screen px-4 py-12 sm:px-6 lg:px-8">
-  <div class="w-full max-w-md">
-    <div>
-      <h2 class="mt-6 text-2xl font-bold tracking-tight text-gray-900 text-center sm:text-3xl">Multicarnes S.R.L.</h2>
-    </div>
+<% input_classes = "block w-full rounded-md border-0 px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
 
-    <div class="mt-8">
-      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6" }) do |f| %>
-        <div>
-          <%= f.label :email, class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2">
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", required: true, class: "block w-full rounded-md bg-white px-3 py-2 text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm sm:text-base" %>
-          </div>
-        </div>
-
-        <div>
-          <%= f.label :password, class: "block text-sm font-medium text-gray-900" %>
-          <div class="relative mt-2" data-controller="password-visibility">
-            <!-- Campo de contraseña -->
-            <%= f.password_field :password, autocomplete: "current-password", required: true, spellcheck: "false",
-                                  class: "block w-full pr-10 rounded-md bg-white px-3 py-2 text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 text-sm sm:text-base",
-                                  "data-password-visibility-target" => "input" %>
-
-            <!-- Botón para alternar visibilidad -->
-            <button type="button" data-action="password-visibility#toggle"
-                    class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-indigo-600 focus:outline-none">
-              <span data-password-visibility-target="icon">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-                </svg>
-              </span>
-              <span data-password-visibility-target="icon" class="hidden">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </div>
-
-        <div class="flex flex-col space-y-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
-          <% if devise_mapping.rememberable? %>
-            <div class="flex items-center gap-3">
-              <%= f.check_box :remember_me, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" %>
-              <%= f.label :remember_me, "Recordar", class: "text-sm text-gray-900" %>
-            </div>
-          <% end %>
-        </div>
-
-        <div>
-          <%= f.submit "Iniciar Sesión", class: "w-full rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 sm:text-base" %>
-        </div>
-      <% end %>
-    </div>
+<div class="sm:mx-auto sm:w-full sm:max-w-md">
+  <div class="mx-auto flex size-12 items-center justify-center rounded-xl bg-indigo-600 shadow-sm">
+    <svg class="size-7 text-white" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+    </svg>
   </div>
+  <h1 class="mt-5 text-center text-2xl font-bold tracking-tight text-gray-900">Multicarnes S.R.L.</h1>
+  <p class="mt-1 text-center text-sm leading-6 text-gray-500">Ingresá a tu cuenta para continuar</p>
+</div>
+
+<div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+  <div class="bg-white px-6 py-10 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl sm:px-10">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6" }) do |f| %>
+      <div>
+        <%= f.label :email, "Correo electrónico", class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", required: true, class: input_classes %>
+        </div>
+      </div>
+
+      <div>
+        <%= f.label :password, "Contraseña", class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="relative mt-2" data-controller="password-visibility">
+          <%= f.password_field :password, autocomplete: "current-password", required: true, spellcheck: "false",
+                                class: "#{input_classes} pr-10",
+                                "data-password-visibility-target" => "input" %>
+
+          <button type="button" data-action="password-visibility#toggle"
+                  class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-indigo-600 focus:outline-none"
+                  aria-label="Mostrar u ocultar contraseña">
+            <span data-password-visibility-target="icon">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+            </span>
+            <span data-password-visibility-target="icon" class="hidden">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <div class="flex items-center justify-between">
+        <% if devise_mapping.rememberable? %>
+          <div class="flex items-center gap-2">
+            <%= f.check_box :remember_me, class: "size-4 rounded border-gray-300 accent-indigo-600" %>
+            <%= f.label :remember_me, "Recordarme", class: "text-sm leading-6 text-gray-700" %>
+          </div>
+        <% end %>
+
+        <% if devise_mapping.recoverable? %>
+          <%= link_to "¿Olvidaste tu contraseña?", new_password_path(resource_name), class: "text-sm font-semibold text-indigo-600 hover:text-indigo-500" %>
+        <% end %>
+      </div>
+
+      <%= f.submit "Iniciar sesión", class: "block w-full cursor-pointer rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+    <% end %>
+  </div>
+
+  <p class="mt-8 text-center text-xs leading-5 text-gray-400">Sistema de control de asistencia</p>
 </div>

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,15 +1,14 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
+  <div id="error_explanation" data-turbo-cache="false" role="alert" class="rounded-md bg-red-50 p-4">
+    <h2 class="text-sm font-medium text-red-800">
+      Se <%= resource.errors.count == 1 ? "encontró 1 error" : "encontraron #{resource.errors.count} errores" %>:
     </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+    <div class="mt-2 text-sm text-red-700">
+      <ul class="list-disc space-y-1 pl-5">
+        <% resource.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 <% end %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,25 +1,11 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+<%# El registro está deshabilitado en rutas (devise_for skip: :registrations): no
+    enlazar new_registration_path aunque el modelo sea registerable — la ruta no existe. %>
+<div class="mt-8 flex flex-col items-center gap-2 text-center text-sm leading-6 text-gray-500">
+  <%- if controller_name != "sessions" %>
+    <%= link_to "Volver a iniciar sesión", new_session_path(resource_name), class: "font-semibold text-indigo-600 hover:text-indigo-500" %>
   <% end %>
-<% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
+    <%= link_to "¿Olvidaste tu contraseña?", new_password_path(resource_name), class: "font-semibold text-indigo-600 hover:text-indigo-500" %>
+  <% end %>
+</div>

--- a/db/migrate/20260716090000_dedupe_events_and_add_unique_index.rb
+++ b/db/migrate/20260716090000_dedupe_events_and_add_unique_index.rb
@@ -1,0 +1,35 @@
+class DedupeEventsAndAddUniqueIndex < ActiveRecord::Migration[8.0]
+  def up
+    # Re-importar exportaciones con rangos solapados insertaba el mismo golpe varias
+    # veces (la tabla no tenía unicidad), y cada duplicado quedaba processed: false,
+    # re-disparando el procesamiento de asistencia sobre días ya cerrados.
+    # Conservamos una fila por golpe, prefiriendo la ya procesada.
+    before = select_value("SELECT COUNT(*) FROM events").to_i
+
+    execute <<~SQL
+      DELETE FROM events WHERE id IN (
+        SELECT id FROM (
+          SELECT id, ROW_NUMBER() OVER (
+            PARTITION BY date, time, s_job_no, event_sub_code
+            ORDER BY processed DESC, id ASC
+          ) AS rn
+          FROM events
+          WHERE s_job_no IS NOT NULL
+        ) WHERE rn > 1
+      );
+    SQL
+
+    after = select_value("SELECT COUNT(*) FROM events").to_i
+    say "Eventos duplicados eliminados: #{before - after}"
+
+    # No incluye serial_no: el dispositivo puede resetearlo al vaciar su log.
+    # s_job_no ya se guarda normalizado (Event#clean_params quita el prefijo ').
+    # Filas manuales con s_job_no NULL no chocan (SQLite trata cada NULL como distinto).
+    add_index :events, [ :date, :time, :s_job_no, :event_sub_code ],
+              unique: true, name: "index_events_on_unique_punch"
+  end
+
+  def down
+    remove_index :events, name: "index_events_on_unique_punch"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_15_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_16_090000) do
   create_table "absences", force: :cascade do |t|
     t.bigint "employee_id", null: false
     t.date "start_date"
@@ -87,6 +87,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_15_120000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "processed", default: false
+    t.index ["date", "time", "s_job_no", "event_sub_code"], name: "index_events_on_unique_punch", unique: true
     t.index ["date", "time"], name: "index_events_on_date_and_time"
     t.index ["device_id"], name: "index_events_on_device_id"
     t.index ["employee_id"], name: "index_events_on_employee_id"

--- a/test/fixtures/files/sereno_events.csv
+++ b/test/fixtures/files/sereno_events.csv
@@ -1,0 +1,5 @@
+sName,sJobNo,sCard,Date,Time,IN/OUT,ReadID,EventMainCode,EventSubCode,AttendanceStatus,WearMask,SerialNo
+DIOSNEL VILLAR,'3489327,'0055012470,2026-06-19,19:54:34,IN,1,5,1,undefined,invalid,51925
+DIOSNEL VILLAR,'3489327,'0055012470,2026-06-20,03:59:15,IN,1,5,1,undefined,invalid,51938
+MIGUEL LEGUIZAMON,'7138042,'0121963449,2026-06-19,13:43:52,IN,1,5,38,undefined,invalid,51794
+,',',2026-06-19,13:44:53,IN,1,5,39,undefined,invalid,51804

--- a/test/models/employee_test.rb
+++ b/test/models/employee_test.rb
@@ -22,7 +22,14 @@
 require "test_helper"
 
 class EmployeeTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "sereno? detects any group containing sereno, like the production name" do
+    assert Employee.new(group: Group.create!(name: "Sereno")).sereno?
+    assert Employee.new(group: Group.create!(name: "Sereno - Diosnel")).sereno?
+    assert Employee.new(group: Group.create!(name: "SERENOS")).sereno?
+  end
+
+  test "sereno? is false for other groups and for employees without group" do
+    assert_not Employee.new(group: Group.create!(name: "Ventas")).sereno?
+    assert_not Employee.new.sereno?
+  end
 end

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -18,7 +18,35 @@
 require "test_helper"
 
 class ScheduleTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "a night schedule crossing midnight is valid and its effective exit falls on the next day" do
+    schedule = night_schedule
+
+    assert schedule.valid?
+    assert schedule.crosses_midnight?
+    assert_equal Time.zone.parse("2026-06-20 04:00:00"), schedule.effective_expected_exit_time
+  end
+
+  test "formatted_duration handles schedules crossing midnight" do
+    assert_equal "08:00 horas", night_schedule.formatted_duration
+  end
+
+  test "a day schedule keeps its exit time as-is" do
+    schedule = Schedule.new(
+      group: Group.create!(name: "Ventas"),
+      expected_entry_time: Time.zone.parse("2026-06-19 07:00:00"),
+      expected_exit_time: Time.zone.parse("2026-06-19 16:00:00")
+    )
+
+    assert_not schedule.crosses_midnight?
+    assert_equal schedule.expected_exit_time, schedule.effective_expected_exit_time
+  end
+
+  private
+    def night_schedule
+      Schedule.new(
+        group: Group.create!(name: "Sereno"),
+        expected_entry_time: Time.zone.parse("2026-06-19 20:00:00"),
+        expected_exit_time: Time.zone.parse("2026-06-19 04:00:00")
+      )
+    end
 end

--- a/test/services/attendance_processor_service_test.rb
+++ b/test/services/attendance_processor_service_test.rb
@@ -2,11 +2,12 @@ require "test_helper"
 
 class AttendanceProcessorServiceTest < ActiveSupport::TestCase
   setup do
+    # Nombre real del grupo en producción: la detección debe funcionar por inclusión.
     @sereno = Employee.create!(
       document_number: "3489327",
       first_name: "DIOSNEL",
       last_name: "VILLAR",
-      group: Group.create!(name: "Sereno")
+      group: Group.create!(name: "Sereno - Diosnel")
     )
   end
 

--- a/test/services/attendance_processor_service_test.rb
+++ b/test/services/attendance_processor_service_test.rb
@@ -1,0 +1,151 @@
+require "test_helper"
+
+class AttendanceProcessorServiceTest < ActiveSupport::TestCase
+  setup do
+    @sereno = Employee.create!(
+      document_number: "3489327",
+      first_name: "DIOSNEL",
+      last_name: "VILLAR",
+      group: Group.create!(name: "Sereno")
+    )
+  end
+
+  test "pairs an evening entry with the next morning exit" do
+    punch "2026-06-19", "19:52:00"
+    punch "2026-06-20", "03:59:00"
+
+    process
+
+    record = records.sole
+    assert_equal at("2026-06-19 19:52:00"), record.entry_time
+    assert_equal at("2026-06-20 03:59:00"), record.exit_time
+    assert_equal 0, Event.where(processed: false).count
+  end
+
+  test "a day-off morning exit never becomes an entry" do
+    # Secuencia real: trabaja viernes a la noche, libra el sábado, vuelve el domingo.
+    punch "2026-06-19", "19:54:34"
+    punch "2026-06-20", "03:59:15"
+    punch "2026-06-21", "19:55:09"
+    punch "2026-06-22", "04:59:56"
+
+    process
+
+    assert_equal 2, records.count
+    assert records.all? { |record| record.exit_time.present? },
+           "la salida matinal del día libre generó un registro espurio sin salida"
+  end
+
+  test "a trailing entry stays pending until the next import brings its exit" do
+    entry = punch "2026-06-19", "19:52:00"
+
+    process
+
+    assert_empty records
+    assert_not entry.reload.processed
+
+    punch "2026-06-20", "03:59:00"
+    process
+
+    assert_equal at("2026-06-20 03:59:00"), records.sole.exit_time
+    assert_equal 0, Event.where(processed: false).count
+  end
+
+  test "a missed exit closes the shift without exit and the next shift pairs normally" do
+    punch "2026-06-19", "19:52:00"
+    punch "2026-06-20", "19:55:00"
+    punch "2026-06-21", "03:58:00"
+
+    process
+
+    assert_equal 2, records.count
+    assert_nil records.find_by(entry_time: at("2026-06-19 19:52:00")).exit_time
+    assert_equal at("2026-06-21 03:58:00"),
+                 records.find_by(entry_time: at("2026-06-20 19:55:00")).exit_time
+  end
+
+  test "re-punches collapse into a single shift" do
+    punch "2026-06-19", "19:50:00"
+    punch "2026-06-19", "19:52:00"
+    punch "2026-06-20", "03:59:00"
+
+    process
+
+    record = records.sole
+    assert_equal at("2026-06-19 19:50:00"), record.entry_time
+    assert_equal at("2026-06-20 03:59:00"), record.exit_time
+    assert_equal 0, Event.where(processed: false).count
+  end
+
+  test "a trailing cluster of re-punches stays pending" do
+    punch "2026-06-19", "19:50:00"
+    punch "2026-06-19", "19:52:00"
+
+    process
+
+    assert_empty records
+    assert_equal 2, Event.where(processed: false).count
+  end
+
+  test "reprocessing an entry never erases the exit of an existing record" do
+    entry = punch "2026-06-19", "19:52:00"
+    punch "2026-06-20", "03:59:00"
+    process
+
+    # Simula una re-importación parcial: la entrada vuelve a quedar sin procesar
+    # y el siguiente evento visible está a más de 14 horas.
+    entry.update!(processed: false)
+    punch "2026-06-22", "19:55:00"
+    process
+
+    record = records.find_by(entry_time: at("2026-06-19 19:52:00"))
+    assert_equal at("2026-06-20 03:59:00"), record.exit_time
+    assert entry.reload.processed
+  end
+
+  test "standard employees keep first-entry/last-exit pairing" do
+    worker = Employee.create!(document_number: "5058650", group: Group.create!(name: "Ventas"))
+    punch "2026-06-19", "07:00:00", employee: worker
+    punch "2026-06-19", "12:00:00", employee: worker
+    punch "2026-06-19", "16:00:00", employee: worker
+
+    process
+
+    record = worker.attendance_records.reload.sole
+    assert_equal at("2026-06-19 07:00:00"), record.entry_time
+    assert_equal at("2026-06-19 16:00:00"), record.exit_time
+  end
+
+  test "standard employees get no exit when the day spans less than 5 hours" do
+    worker = Employee.create!(document_number: "5058650", group: Group.create!(name: "Ventas"))
+    punch "2026-06-19", "07:00:00", employee: worker
+    punch "2026-06-19", "09:00:00", employee: worker
+
+    process
+
+    assert_nil worker.attendance_records.reload.sole.exit_time
+  end
+
+  private
+    def punch(date, time, employee: @sereno)
+      Event.create!(
+        employee: employee,
+        s_job_no: employee.document_number,
+        date: date,
+        time: time,
+        in_out: "IN"
+      )
+    end
+
+    def process
+      AttendanceProcessorService.new.call
+    end
+
+    def records
+      @sereno.attendance_records.reload
+    end
+
+    def at(datetime)
+      Time.zone.parse(datetime)
+    end
+end

--- a/test/services/attendance_processor_service_test.rb
+++ b/test/services/attendance_processor_service_test.rb
@@ -116,6 +116,24 @@ class AttendanceProcessorServiceTest < ActiveSupport::TestCase
     assert_equal at("2026-06-19 16:00:00"), record.exit_time
   end
 
+  test "mid-day re-punches are consumed by the day's record and never resurface" do
+    # Caso real: entrada 04:02 y dos golpes al salir (14:25 y 14:30). El golpe
+    # intermedio quedaba pendiente y la siguiente corrida lo convertía en un
+    # registro basura "14:25 sin salida".
+    worker = Employee.create!(document_number: "7138042", group: Group.create!(name: "Ventas"))
+    punch "2026-06-24", "04:02:08", employee: worker
+    punch "2026-06-24", "14:25:17", employee: worker
+    punch "2026-06-24", "14:30:52", employee: worker
+
+    process
+    assert_equal 0, Event.where(processed: false).count
+
+    process
+    record = worker.attendance_records.reload.sole
+    assert_equal at("2026-06-24 04:02:08"), record.entry_time
+    assert_equal at("2026-06-24 14:30:52"), record.exit_time
+  end
+
   test "standard employees get no exit when the day spans less than 5 hours" do
     worker = Employee.create!(document_number: "5058650", group: Group.create!(name: "Ventas"))
     punch "2026-06-19", "07:00:00", employee: worker

--- a/test/services/event_import_service_test.rb
+++ b/test/services/event_import_service_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class EventImportServiceTest < ActiveSupport::TestCase
+  test "imports device rows and auto-creates employees by document" do
+    result = EventImportService.new(file_fixture("sereno_events.csv").to_s).call
+
+    assert_equal 4, result[:total_imported]
+    assert_equal 0, result[:skipped_duplicates]
+    assert_empty result[:errors]
+
+    assert Employee.exists?(document_number: "3489327")
+    assert_equal "3489327", Event.find_by(serial_no: 51925).s_job_no
+  end
+
+  test "rows without a real document create no employee and no attendance" do
+    EventImportService.new(file_fixture("sereno_events.csv").to_s).call
+
+    failed_read = Event.find_by(serial_no: 51804)
+    assert_nil failed_read.employee_id
+    assert_not Employee.exists?(document_number: "")
+    assert_not AttendanceRecord.exists?(entry_time: Time.zone.parse("2026-06-19 13:44:53"))
+  end
+
+  test "re-importing the same file skips every row as duplicate" do
+    EventImportService.new(file_fixture("sereno_events.csv").to_s).call
+    events_before = Event.count
+    records_before = AttendanceRecord.count
+
+    result = EventImportService.new(file_fixture("sereno_events.csv").to_s).call
+
+    assert_equal 0, result[:total_imported]
+    assert_equal 4, result[:skipped_duplicates]
+    assert_empty result[:errors]
+    assert_equal events_before, Event.count
+    assert_equal records_before, AttendanceRecord.count
+  end
+end

--- a/test/services/overtime_calculator_test.rb
+++ b/test/services/overtime_calculator_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class OvertimeCalculatorTest < ActiveSupport::TestCase
+  setup do
+    # AppSetting.[]= está roto (ver workaround en Admin::SettingsController); insertamos directo.
+    now = Time.current
+    AppSetting.insert({ key: "overtime_rate", value: "1000", created_at: now, updated_at: now })
+    AppSetting.insert({ key: "margin_of_tolerance", value: "5", created_at: now, updated_at: now })
+
+    @sereno = Employee.create!(document_number: "3489327", group: Group.create!(name: "Sereno"))
+    @night_schedule = Schedule.create!(
+      group: @sereno.group,
+      expected_entry_time: Time.zone.parse("2026-06-19 20:00:00"),
+      expected_exit_time: Time.zone.parse("2026-06-19 04:00:00")
+    )
+  end
+
+  test "a normal night shift produces no overtime" do
+    record = attendance(entry: "2026-06-19 19:55:00", exit: "2026-06-20 03:50:00")
+
+    assert_equal 0, OvertimeCalculator.new(record, @night_schedule, false).calculate_overtime_hours
+  end
+
+  test "leaving after the effective morning exit produces the real extra hours" do
+    record = attendance(entry: "2026-06-19 19:55:00", exit: "2026-06-20 05:30:00")
+
+    hours = OvertimeCalculator.new(record, @night_schedule, false).calculate_overtime_hours
+    assert_in_delta 1.5, hours, 0.01
+  end
+
+  test "day schedules keep their overtime behavior" do
+    worker = Employee.create!(document_number: "5058650", group: Group.create!(name: "Ventas"))
+    day_schedule = Schedule.create!(
+      group: worker.group,
+      expected_entry_time: Time.zone.parse("2026-06-19 07:00:00"),
+      expected_exit_time: Time.zone.parse("2026-06-19 16:00:00")
+    )
+    record = AttendanceRecord.create!(
+      employee: worker,
+      device: devices(:one),
+      entry_time: Time.zone.parse("2026-06-19 07:00:00"),
+      exit_time: Time.zone.parse("2026-06-19 18:00:00")
+    )
+
+    hours = OvertimeCalculator.new(record, day_schedule, false).calculate_overtime_hours
+    assert_in_delta 2.0, hours, 0.01
+  end
+
+  private
+    def attendance(entry:, exit:)
+      AttendanceRecord.create!(
+        employee: @sereno,
+        device: devices(:one),
+        entry_time: Time.zone.parse(entry),
+        exit_time: Time.zone.parse(exit)
+      )
+    end
+end

--- a/test/services/work_hours_service_test.rb
+++ b/test/services/work_hours_service_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class WorkHoursServiceTest < ActiveSupport::TestCase
+  setup do
+    # AppSetting.[]= está roto (ver workaround en Admin::SettingsController); insertamos directo.
+    now = Time.current
+    AppSetting.insert({ key: "overtime_rate", value: "1000", created_at: now, updated_at: now })
+
+    @sereno = Employee.create!(document_number: "3489327", group: Group.create!(name: "Sereno"))
+    create_night_schedule("2026-06-19")
+    create_night_schedule("2026-06-20")
+
+    AttendanceRecord.create!(
+      employee: @sereno,
+      device: devices(:one),
+      entry_time: Time.zone.parse("2026-06-19 19:54:00"),
+      exit_time: Time.zone.parse("2026-06-20 03:59:00")
+    )
+  end
+
+  test "the morning after the last worked night is not flagged as absent for a sereno" do
+    WorkHoursService.new(@sereno.id, "2026-06-19", "2026-06-20").process_overtime
+
+    assert_empty absence_incidents
+  end
+
+  test "a scheduled night with no attendance at all still creates the incident" do
+    create_night_schedule("2026-06-21")
+
+    WorkHoursService.new(@sereno.id, "2026-06-19", "2026-06-21").process_overtime
+
+    assert_equal [ Date.parse("2026-06-21") ], absence_incidents.map(&:date)
+  end
+
+  test "a normal night shift generates no overtime records" do
+    WorkHoursService.new(@sereno.id, "2026-06-19", "2026-06-20").process_overtime
+
+    assert_empty @sereno.overtime_records
+  end
+
+  private
+    def create_night_schedule(date)
+      Schedule.create!(
+        group: @sereno.group,
+        expected_entry_time: Time.zone.parse("#{date} 20:00:00"),
+        expected_exit_time: Time.zone.parse("#{date} 04:00:00")
+      )
+    end
+
+    def absence_incidents
+      @sereno.incidents.where("issue LIKE ?", "No se presentó%")
+    end
+end


### PR DESCRIPTION
## Resumen

El cliente reportaba un error recurrente con "el usuario SENERO" — el **sereno** (vigilante nocturno, grupo \"Sereno\"). El análisis con un export real del dispositivo (`recordList.csv`) confirmó varios bugs en el pipeline de asistencia, más problemas que afectaban a todos los empleados en importaciones repetidas.

### Fixes de asistencia
- **Sereno** (`31522df`): el emparejamiento por fecha reutilizaba la salida matinal (~04:00) como "entrada" en días con un solo evento → registros espurios "entrada 03:59 sin salida" e incidencias falsas. Reescrito como stream cronológico con ventana de 14h/guard de 4h; las entradas al final del archivo quedan pendientes hasta que la próxima importación traiga la salida; un reproceso nunca borra la salida de un registro correcto.
- **Golpes intermedios** (`19743fb`): el emparejamiento estándar solo marcaba primero/último golpe del día como procesados; las re-marcaciones intermedias quedaban pendientes y cada importación siguiente las convertía en registros basura "sin salida" (30 registros basura en la 2ª corrida con datos reales). El registro del día ahora consume todos sus golpes.
- **Medianoche** (`460c6ce`): `OvertimeCalculator` comparaba la salida real (día siguiente 03:59) contra la salida esperada del mismo día → **~24h de horas extras fantasma por noche**. `Schedule#effective_expected_exit_time` corre la salida al día siguiente cuando el horario cruza la medianoche; `verify_missing_attendance` cuenta la mañana de salida del sereno como asistida.

### Fixes de importación
- **Dedup** (`9a181e6`): índice único sobre `(date, time, s_job_no, event_sub_code)` + limpieza de duplicados existentes; re-importar rangos solapados ya no duplica eventos. El resultado de la importación ahora se muestra (antes siempre decía "exitosamente" aunque fallara).
- **Empleado fantasma** (`c028e98`): las lecturas fallidas (sJobNo = `'`) creaban un empleado con documento vacío que acumulaba asistencia.

### UI
- **Login y recuperación de contraseña** (`d5911c1`, `6b0f2c8`): layout centrado y responsive, vistas en español con el sistema visual de la app; la página de recuperación crasheaba por un link a `new_registration_path` (ruta deshabilitada).

Incluye también `6b33869` (perf: N+1s, índices, writes-on-read), base de esta rama.

## Verificación

- Suite: 23 tests, 0 fallos (13 nuevos de servicios). RuboCop y Brakeman limpios.
- E2E con el CSV real (661 filas): el sereno produce 13 turnos limpios de ~8h, cero espurios; re-importar el mismo archivo es no-op; importarlo en dos mitades solapadas produce registros idénticos a la corrida única; nómina sin incidencias falsas y con extras reales (no 24h).
- Login verificado con screenshots (desktop y móvil).

## Pendiente (etapa 2, fuera de este PR)

Reparación de datos históricos en la BD del cliente (borrar registros/incidencias/extras corruptos del sereno y regenerar nóminas afectadas). Hasta entonces, no regenerar nóminas de períodos anteriores al deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)