### PR TITLE
Fix: AppSetting rompía db:migrate (annotate) y su propio setter

### DIFF
--- a/app/models/app_setting.rb
+++ b/app/models/app_setting.rb
@@ -1,16 +1,12 @@
 # == Schema Information
 #
-# Table name: settings
+# Table name: app_settings
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
+#  key        :string
 #  value      :text
-#  var        :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#
-# Indexes
-#
-#  index_settings_on_var  (var) UNIQUE
 #
 # app/models/AppSetting.rb
 class AppSetting < ApplicationRecord
@@ -37,8 +33,13 @@ class AppSetting < ApplicationRecord
     end
   end
 
+  # No declarar respond_to? true para cualquier método: gemas que hacen sondeo
+  # (annotaterb pregunta respond_to?(:translation_class) y luego llama al método,
+  # que devuelve nil → rompía db:migrate) y la introspección de validaciones de
+  # ActiveRecord se confunden. La notación por punto (AppSetting.lunch_hours)
+  # sigue funcionando vía method_missing, que no consulta respond_to?.
   def self.respond_to_missing?(method_name, include_private = false)
-    true
+    super
   end
 
   # Automatically convert values to appropriate types


### PR DESCRIPTION
## Problema

Al correr `bin/rails db:migrate` en un entorno de desarrollo (ej. el EC2), el paso "Annotating models" abortaba con:

```
NoMethodError: undefined method 'columns' for nil
        @klass.translation_class.columns.reject do |col|
```

## Causa

`AppSetting.respond_to_missing?` devolvía `true` incondicionalmente. Cualquier gema que sondea métodos caía en la trampa: `annotaterb` pregunta `respond_to?(:translation_class)` (detección de Globalize), recibe `true`, llama al método, recibe `nil` (lo resuelve como si fuera una configuración) y explota. La misma mentira corrompía la introspección de validaciones de ActiveRecord — por eso `AppSetting.[]=` generaba SQL inválido y `Admin::SettingsController` necesita el workaround con `insert`.

## Fix

`respond_to_missing?` delega en `super`. Verificado:
- `AppSetting.respond_to?(:translation_class)` → `false` → `db:migrate` anota los 36 modelos sin error.
- La lectura por punto (`AppSetting.lunch_hours`) sigue funcionando — `method_missing` no consulta `respond_to?`.
- **Bonus:** el setter `AppSetting["clave"] = valor` vuelve a funcionar (la validación de unicidad ya genera SQL correcto). El workaround del controller queda como está (es inofensivo).

No afecta al build de Windows del cliente: `annotaterb` es dev-only.

Suite completa verde (25 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)