### PR TITLE
Fix: dashboard portable entre SQLite y Postgres (crash de strftime)

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -39,10 +39,14 @@ class HomeController < ApplicationController
   private
 
   def calculate_attendance_rate
-    # Get unique employees who were scheduled during this period
-    scheduled_employees = Employee.joins(:schedule)
-                                 .where("schedules.workday && ARRAY[?]::integer[]", workdays_in_range)
-                                 .distinct.count
+    # Empleados con horario en el período: los de grupos que tienen un Schedule
+    # fechado dentro del rango. Reemplaza la consulta rota sobre
+    # "schedules.workday && ARRAY[...]" (Postgres-only y sobre una columna que ya
+    # no existe), que siempre fallaba y dejaba la tasa en 0.
+    scheduled_dates = @date_range.first.to_date..@date_range.last.to_date
+    scheduled_employees = Employee.where(
+      group_id: Schedule.where(date: scheduled_dates).select(:group_id)
+    ).count
 
     # Get unique employees who actually attended
     attending_employees = Employee.joins(:attendance_records)
@@ -57,16 +61,5 @@ class HomeController < ApplicationController
     # Fallback if there's an error
     @attendance_rate = 0
     Rails.logger.error("Error calculating attendance rate: #{e.message}")
-  end
-
-  def workdays_in_range
-    case @filter
-    when "week"
-      (Date.today.beginning_of_week..Date.today).map(&:wday)
-    when "month"
-      (Date.today.beginning_of_month..Date.today).map(&:wday).uniq
-    else
-      [ Date.today.wday ]
-    end
   end
 end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,2 +1,17 @@
 module HomeHelper
+  # Distribución de horarios por turno según la hora local de entrada.
+  # Calculado en Ruby para ser portable entre SQLite (escritorio) y Postgres
+  # (el strftime anterior era SQLite-only y rompía el dashboard en Postgres).
+  def schedule_shift_distribution
+    entry_hours = Schedule.joins(:group)
+                          .pluck(:expected_entry_time)
+                          .compact
+                          .map { |time| time.in_time_zone.hour }
+
+    {
+      morning: entry_hours.count { |hour| hour.between?(5, 11) },
+      afternoon: entry_hours.count { |hour| hour.between?(12, 17) },
+      night: entry_hours.count { |hour| hour >= 18 || hour <= 4 }
+    }
+  end
 end

--- a/app/services/time_metrics_service.rb
+++ b/app/services/time_metrics_service.rb
@@ -45,19 +45,20 @@ class TimeMetricsService
   end
 
   def calculate_punctuality_rate
-    total_records = AttendanceRecord.joins(:schedule)
-                                   .where(entry_time: date_range)
-                                   .count
+    # Comparado en Ruby para ser portable: el datetime(..., '+15 minutes') era
+    # SQLite-only y el "+ interval" anterior era Postgres-only. El rango es corto
+    # (día/semana/mes de una sola empresa), así que la carga en memoria es chica.
+    records = AttendanceRecord.includes(:schedule)
+                              .where(entry_time: date_range)
+                              .select(&:schedule)
 
-    return 0 if total_records.zero?
+    return 0 if records.empty?
 
-    # SQLite datetime arithmetic (the Postgres "+ interval '15 minute'" is not portable).
-    on_time_records = AttendanceRecord.joins(:schedule)
-                                     .where(entry_time: date_range)
-                                     .where("entry_time <= datetime(schedules.expected_entry_time, '+15 minutes')")
-                                     .count
+    on_time = records.count do |record|
+      record.entry_time <= record.schedule.expected_entry_time + 15.minutes
+    end
 
-    ((on_time_records.to_f / total_records) * 100).round
+    ((on_time.to_f / records.size) * 100).round
   end
 
   def calculate_late_rate
@@ -66,32 +67,24 @@ class TimeMetricsService
   end
 
   def calculate_absence_rate
-    # Fix the association - Employee likely has a schedule (singular) association
-    # or we need to join through another model
-    total_expected = Employee.joins(:schedule)
-                            .where("schedules.workday && ARRAY[?]::integer[]", workdays_in_range)
-                            .count
+    # Asistencias esperadas = por cada horario del rango (grupo + fecha), la
+    # cantidad de empleados de ese grupo. Reemplaza la consulta rota sobre
+    # "schedules.workday && ARRAY[...]" (Postgres-only y sobre una columna que
+    # ya no existe), que siempre fallaba y devolvía un 3% inventado.
+    schedules_per_group = Schedule.where(date: scheduled_dates).group(:group_id).count
+    return 0 if schedules_per_group.empty?
 
+    employees_per_group = Employee.where(group_id: schedules_per_group.keys).group(:group_id).count
+    total_expected = schedules_per_group.sum { |group_id, days| days * employees_per_group.fetch(group_id, 0) }
     return 0 if total_expected.zero?
 
     actual_attendance = AttendanceRecord.where(entry_time: date_range).count
 
     absence_count = [ total_expected - actual_attendance, 0 ].max
     ((absence_count.to_f / total_expected) * 100).round
-  rescue ActiveRecord::ConfigurationError
-    # Fallback if the association is still incorrect
-    # This is a temporary solution until we can fix the model associations
-    3 # Return a default value for now
   end
 
-  def workdays_in_range
-    case filter
-    when "week"
-      (Date.today.beginning_of_week..Date.today).map(&:wday)
-    when "month"
-      (Date.today.beginning_of_month..Date.today).map(&:wday).uniq
-    else
-      [ Date.today.wday ]
-    end
+  def scheduled_dates
+    date_range.first.to_date..date_range.last.to_date
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -155,24 +155,13 @@
       <h3 class="text-base font-semibold text-gray-900">Distribución por Turnos</h3>
     </div>
     <div class="p-5">
-      <% 
-        # Obtener horarios agrupados por hora de entrada
-        # SQLite: cast(strftime('%H', ...) as integer) replaces Postgres "extract(hour from ...)"
-        morning_schedules = Schedule.where("cast(strftime('%H', expected_entry_time) as integer) BETWEEN 5 AND 11")
-                            .joins(:group).count
+      <%
+        shifts = schedule_shift_distribution
+        total_schedules = [ shifts.values.sum, 1 ].max
 
-        afternoon_schedules = Schedule.where("cast(strftime('%H', expected_entry_time) as integer) BETWEEN 12 AND 17")
-                              .joins(:group).count
-
-        night_schedules = Schedule.where("cast(strftime('%H', expected_entry_time) as integer) BETWEEN 18 AND 23 OR cast(strftime('%H', expected_entry_time) as integer) BETWEEN 0 AND 4")
-                          .joins(:group).count
-        
-        total_schedules = morning_schedules + afternoon_schedules + night_schedules
-        total_schedules = total_schedules > 0 ? total_schedules : 1
-        
-        morning_percent = (morning_schedules.to_f / total_schedules * 100).round
-        afternoon_percent = (afternoon_schedules.to_f / total_schedules * 100).round
-        night_percent = (night_schedules.to_f / total_schedules * 100).round
+        morning_percent = (shifts[:morning].to_f / total_schedules * 100).round
+        afternoon_percent = (shifts[:afternoon].to_f / total_schedules * 100).round
+        night_percent = (shifts[:night].to_f / total_schedules * 100).round
       %>
       
       <div class="space-y-4">

--- a/test/helpers/home_helper_test.rb
+++ b/test/helpers/home_helper_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class HomeHelperTest < ActionView::TestCase
+  test "schedule_shift_distribution buckets schedules by local entry hour" do
+    day_group = Group.create!(name: "Ventas")
+    night_group = Group.create!(name: "Sereno - Diosnel")
+
+    create_schedule day_group, "2026-07-13 07:00", "2026-07-13 16:00"
+    create_schedule day_group, "2026-07-14 13:00", "2026-07-14 18:00"
+    create_schedule night_group, "2026-07-13 20:00", "2026-07-13 04:00"
+
+    assert_equal({ morning: 1, afternoon: 1, night: 1 }, schedule_shift_distribution)
+  end
+
+  private
+    def create_schedule(group, entry, exit_time)
+      Schedule.create!(
+        group: group,
+        expected_entry_time: Time.zone.parse(entry),
+        expected_exit_time: Time.zone.parse(exit_time)
+      )
+    end
+end

--- a/test/services/time_metrics_service_test.rb
+++ b/test/services/time_metrics_service_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class TimeMetricsServiceTest < ActiveSupport::TestCase
+  setup do
+    @group = Group.create!(name: "Ventas")
+    @employee = Employee.create!(document_number: "5058650", group: @group)
+    Schedule.create!(
+      group: @group,
+      expected_entry_time: Time.zone.parse("#{Date.today} 07:00"),
+      expected_exit_time: Time.zone.parse("#{Date.today} 16:00")
+    )
+  end
+
+  test "punctuality compares entries against the schedule with 15 minutes of tolerance" do
+    record_for @employee, entry: "07:05"
+
+    late = Employee.create!(document_number: "7444871", group: @group)
+    record_for late, entry: "07:40"
+
+    assert_equal 50, TimeMetricsService.new("today").calculate[:punctuality_rate]
+  end
+
+  test "absence rate counts expected attendances from scheduled groups" do
+    Employee.create!(document_number: "7444871", group: @group)
+    record_for @employee, entry: "07:05"
+
+    # 1 horario hoy x 2 empleados del grupo = 2 esperadas; 1 asistencia -> 50%
+    assert_equal 50, TimeMetricsService.new("today").calculate[:absence_rate]
+  end
+
+  private
+    def record_for(employee, entry:)
+      AttendanceRecord.create!(
+        employee: employee,
+        device: devices(:one),
+        entry_time: Time.zone.parse("#{Date.today} #{entry}"),
+        exit_time: Time.zone.parse("#{Date.today} 16:00")
+      )
+    end
+end


### PR DESCRIPTION
## Problema

En el despliegue EC2 (que corre sobre **Postgres**), el home crasheaba:

```
PG::UndefinedFunction: ERROR: function strftime(unknown, timestamp without time zone) does not exist
```

El código quedó a mitad de camino entre dos dialectos tras la conversión a SQLite para el build de escritorio:

| Lugar | Problema |
|---|---|
| `home/index.html.erb` (distribución por turnos) | `strftime` — SQLite-only → **crash en Postgres** |
| `TimeMetricsService#calculate_punctuality_rate` | `datetime(..., '+15 minutes')` — SQLite-only (bomba latente: hoy no explota solo porque el join da 0) |
| `HomeController#calculate_attendance_rate` y `TimeMetricsService#calculate_absence_rate` | `schedules.workday && ARRAY[...]` — **Postgres-only** y sobre una columna que ya no existe: fallaba siempre en ambas bases → tasa de asistencia 0% y ausencias 3% hardcodeado |

## Fix

Todo pasa a ActiveRecord puro + Ruby (sin SQL crudo), portable por construcción:

- **Turnos** → `HomeHelper#schedule_shift_distribution`: clasifica por hora local de entrada (antes clasificaba por hora UTC, con desfase de 3h en los buckets).
- **Puntualidad** → compara `entry_time` contra el horario en Ruby (misma tolerancia de 15 min).
- **Tasas de asistencia/ausencia** → esperadas reales a partir de los `Schedule` fechados en el rango (horarios del grupo × empleados del grupo), en lugar de la consulta rota.

## Verificación

- Suite completa verde (28 tests; nuevos: helper de turnos + puntualidad + ausencias).
- Smoke E2E local (SQLite): login + render del home → 200 con la sección "Distribución por Turnos" completa.
- RuboCop limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)