### PR TITLE
Fix: PG::GroupingError en el home (default_scope + GROUP BY)

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -45,7 +45,7 @@ class HomeController < ApplicationController
     # no existe), que siempre fallaba y dejaba la tasa en 0.
     scheduled_dates = @date_range.first.to_date..@date_range.last.to_date
     scheduled_employees = Employee.where(
-      group_id: Schedule.where(date: scheduled_dates).select(:group_id)
+      group_id: Schedule.where(date: scheduled_dates).reorder(nil).select(:group_id)
     ).count
 
     # Get unique employees who actually attended

--- a/app/services/time_metrics_service.rb
+++ b/app/services/time_metrics_service.rb
@@ -71,7 +71,9 @@ class TimeMetricsService
     # cantidad de empleados de ese grupo. Reemplaza la consulta rota sobre
     # "schedules.workday && ARRAY[...]" (Postgres-only y sobre una columna que
     # ya no existe), que siempre fallaba y devolvía un 3% inventado.
-    schedules_per_group = Schedule.where(date: scheduled_dates).group(:group_id).count
+    # reorder(nil) quita el ORDER BY date del default_scope: Postgres rechaza
+    # ordenar por una columna no agrupada (SQLite lo tolera y no lo detecta).
+    schedules_per_group = Schedule.where(date: scheduled_dates).reorder(nil).group(:group_id).count
     return 0 if schedules_per_group.empty?
 
     employees_per_group = Employee.where(group_id: schedules_per_group.keys).group(:group_id).count


### PR DESCRIPTION
## Problema

Tras el PR #97, el home crasheaba en el despliegue Postgres:

```
PG::GroupingError: column "schedules.date" must appear in the GROUP BY clause
```

## Causa

`Schedule` tiene `default_scope { order(date: :desc) }`. La consulta nueva de tasa de ausencias (`GROUP BY group_id`) heredó ese `ORDER BY` sobre una columna no agrupada. SQLite lo tolera en silencio (por eso los tests pasaron); Postgres lo rechaza.

## Fix

`reorder(nil)` en la consulta agrupada y en la subconsulta de empleados con horario (donde el orden heredado era inútil). Verificado: el SQL generado ya no lleva `ORDER BY`; suite completa verde (28 tests).

Se auditaron los demás `group()` del proyecto: `GroupsController#index` agrupa por PK sin default_scope de orden — seguro en ambas bases.

**Nota:** los tests corren sobre SQLite, que no puede detectar esta clase de error. Si el despliegue Postgres va a seguir siendo productivo, valdría agregar un job de CI que corra la suite contra Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)